### PR TITLE
Move search suggestion dropdown in front of search result cards

### DIFF
--- a/services/query-engine/resources/css/app.css
+++ b/services/query-engine/resources/css/app.css
@@ -238,12 +238,8 @@ footer a {
 #search-suggestions {
     background-color: var(--text);
     color: var(--bg);
+    z-index: 1000;
     @apply border border-gray-400 w-140 h-auto;
-
-}
-
-#search-suggestions-list {
-
 }
 
 .search-suggestion {


### PR DESCRIPTION
Small PR to fix #2 

### Changes
- Added `z-index: 1000` to the search suggestions style to move the element to the front.
- Removed empty `#search-suggestions-list`.

![444800449-fc4a850c-bc61-4011-8857-7f604f7b4ab2](https://github.com/user-attachments/assets/34c36f48-da5e-4584-968b-d1724fa22324)